### PR TITLE
Fix matching against union of tuples

### DIFF
--- a/mypy/checkpattern.py
+++ b/mypy/checkpattern.py
@@ -271,7 +271,9 @@ class PatternChecker(PatternVisitor[PatternType]):
                     elif size_diff > 0 and star_position is None:
                         continue
                     elif not size_diff and star_position is not None:
-                        t_items.append(UninhabitedType()) # add additional item for star if its empty
+                        t_items.append(
+                            UninhabitedType()
+                        )  # add additional item for star if its empty
                     tuple_types.append(t_items)
                 else:
                     normalized_inner_types = []

--- a/mypy/checkpattern.py
+++ b/mypy/checkpattern.py
@@ -271,9 +271,7 @@ class PatternChecker(PatternVisitor[PatternType]):
                     elif size_diff > 0 and star_position is None:
                         continue
                     elif not size_diff and star_position is not None:
-                        t_items.append(
-                            UninhabitedType()
-                        )  # add additional item for star if its empty
+                        t_items.append(UninhabitedType())
                     tuple_types.append(t_items)
                 else:
                     normalized_inner_types = []

--- a/mypy/checkpattern.py
+++ b/mypy/checkpattern.py
@@ -255,14 +255,20 @@ class PatternChecker(PatternVisitor[PatternType]):
         state: (
             # Start in the state where we not encountered an unpack.
             # a list of all the possible types that could match the sequence. If it's a tuple, then store one for each index
-            tuple[Literal["NO_UNPACK"], list[list[Type]]] |
+            tuple[Literal["NO_UNPACK"], list[list[Type]]]
+            |
             # If we encounter a single tuple with an unpack, store the type, the unpack index, and the index in the union type
-            tuple[Literal["UNPACK"], TupleType, int, int] |
+            tuple[Literal["UNPACK"], TupleType, int, int]
+            |
             # If we have encountered a tuple with an unpack plus any other types, then store a list of them. For any tuples
             # without unpacks, store them as a list of their items.
             tuple[Literal["MULTI_UNPACK"], list[list[Type]]]
-         ) = ("NO_UNPACK", [])
-        for i, t in enumerate(current_type.items) if isinstance(current_type, UnionType) else ((0, current_type),):
+        ) = ("NO_UNPACK", [])
+        for i, t in (
+            enumerate(current_type.items)
+            if isinstance(current_type, UnionType)
+            else ((0, current_type),)
+        ):
             t = get_proper_type(t)
             n_patterns = len(o.patterns)
             if isinstance(t, TupleType):
@@ -301,8 +307,11 @@ class PatternChecker(PatternVisitor[PatternType]):
             # if we previously encountered an unpack, then change the state.
             if state[0] == "UNPACK":
                 # if we already unpacked something, change this
-                state = ("MULTI_UNPACK", [[self.chk.iterable_item_type(tuple_fallback(state[1]), o)] * n_patterns])
-            assert state[0] != "UNPACK" # for type checker
+                state = (
+                    "MULTI_UNPACK",
+                    [[self.chk.iterable_item_type(tuple_fallback(state[1]), o)] * n_patterns],
+                )
+            assert state[0] != "UNPACK"  # for type checker
             state[1].append(inner_t)
         if state[0] == "UNPACK":
             _, update_tuple_type, unpack_index, union_index = state
@@ -318,7 +327,10 @@ class PatternChecker(PatternVisitor[PatternType]):
             unpack_index = None
             if not state[1]:
                 return self.early_non_match()
-            inner_types = [make_simplified_union(x) for x in zip_longest(*state[1], fillvalue=UninhabitedType())]
+            inner_types = [
+                make_simplified_union(x)
+                for x in zip_longest(*state[1], fillvalue=UninhabitedType())
+            ]
 
         #
         # match inner patterns

--- a/mypy/checkpattern.py
+++ b/mypy/checkpattern.py
@@ -315,8 +315,8 @@ class PatternChecker(PatternVisitor[PatternType]):
             inner_types = [make_simplified_union([*sequence_types, *x]) for x in zip(*tuple_types)]
         else:
             object_type = self.chk.named_type("builtins.object")
-            inner_type = make_simplified_union(sequence_types) if sequence_types else object_type
-            inner_types = [inner_type] * len(o.patterns)
+            unioned = make_simplified_union(sequence_types) if sequence_types else object_type
+            inner_types = [unioned] * len(o.patterns)
 
         #
         # match inner patterns

--- a/mypy/checkpattern.py
+++ b/mypy/checkpattern.py
@@ -247,8 +247,9 @@ class PatternChecker(PatternVisitor[PatternType]):
         # get inner types of original type
         #
         # 1. Go through all possible types and filter to only those which are sequences that could match that number of items
-        # 2. If there are multiple tuples left with unpacks, then use the fallback logic where we union all items types
-        # 3. Otherwise, take the product of the item types so that each index can have a unique type
+        # 2. If there is exactly one tuple left with an unpack, then use that type and the unpack index
+        # 3. Otherwise, take the product of the item types so that each index can have a unique type. For tuples with unpack
+        #    fallback to merging all of their types for each index since we can't handle multiple unpacked items at once yet.
 
         #  state of matching
         state: (
@@ -303,7 +304,6 @@ class PatternChecker(PatternVisitor[PatternType]):
                 state = ("MULTI_UNPACK", [[self.chk.iterable_item_type(tuple_fallback(state[1]), o)] * n_patterns])
             assert state[0] != "UNPACK" # for type checker
             state[1].append(inner_t)
-
         if state[0] == "UNPACK":
             _, update_tuple_type, unpack_index, union_index = state
             inner_types = update_tuple_type.items

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -2918,6 +2918,15 @@ class UnionType(ProperType):
         self.original_str_expr: str | None = None
         self.original_str_fallback: str | None = None
 
+    def copy_modified(self, *, items: Sequence[Type]) -> UnionType:
+        return UnionType(
+            items,
+            line=self.line,
+            column=self.column,
+            is_evaluated=self.is_evaluated,
+            uses_pep604_syntax=self.uses_pep604_syntax,
+        )
+
     def can_be_true_default(self) -> bool:
         return any(item.can_be_true for item in self.items)
 

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1602,11 +1602,11 @@ match m6:
         reveal_type(b6)  # N: Revealed type is "Union[builtins.int, builtins.float, builtins.str]"
 
 # but do still seperate types from non unpacked types
-m7: tuple[int, Unpack[tuple[float, ...]]] | tuple[str, bool]
+m7: tuple[int, Unpack[tuple[float, ...]]] | tuple[str, str]
 match m7:
     case (a7, b7, *rest7):
         reveal_type(a7)  # N: Revealed type is "Union[builtins.int, builtins.float, builtins.str]"
-        reveal_type(b7)  # N: Revealed type is "Union[builtins.int, builtins.float, builtins.bool]"
+        reveal_type(b7)  # N: Revealed type is "Union[builtins.int, builtins.float, builtins.str]"
         reveal_type(rest7)  # N: Revealed type is "builtins.list[Union[builtins.int, builtins.float]]"
 
 # verify that if we are unpacking, it will get the type of the sequence if the tuple is too short

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1613,8 +1613,8 @@ match m7:
 m8: tuple[int, str] | list[float]
 match m8:
     case (a8, b8, *rest8):
-        reveal_type(a8)  # N: Revealed type is "Union[builtins.int, builtins.float]"
-        reveal_type(b8)  # N: Revealed type is "Union[builtins.str, builtins.float]"
+        reveal_type(a8)  # N: Revealed type is "Union[builtins.float, builtins.int]"
+        reveal_type(b8)  # N: Revealed type is "Union[builtins.float, builtins.str]"
         reveal_type(rest8)  # N: Revealed type is "builtins.list[builtins.float]"
 
 [builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1559,6 +1559,16 @@ match m6:
 
 [builtins fixtures/tuple.pyi]
 
+[case testMatchTupleFields]
+x: tuple[int, str] | None
+match x:
+    case (a, b):
+        reveal_type(a)  # N: Revealed type is "int"
+        reveal_type(b)  # N: Revealed type is "str"
+
+[builtins fixtures/tuple.pyi]
+
+
 [case testMatchEnumSingleChoice]
 from enum import Enum
 from typing import NoReturn

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1601,7 +1601,7 @@ match m6:
         reveal_type(a6)  # N: Revealed type is "Union[builtins.int, builtins.float, builtins.str]"
         reveal_type(b6)  # N: Revealed type is "Union[builtins.int, builtins.float, builtins.str]"
 
-# but do still seperate types from non unpacked types
+# but do still separate types from non unpacked types
 m7: tuple[int, Unpack[tuple[float, ...]]] | tuple[str, str]
 match m7:
     case (a7, b7, *rest7):

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1560,29 +1560,62 @@ match m6:
 [builtins fixtures/tuple.pyi]
 
 [case testMatchTupleUnions]
+from typing_extensions import Unpack
+
 m1: tuple[int, str] | None
 match m1:
     case (a1, b1):
-        reveal_type(a1)  # N: Revealed type is "int"
-        reveal_type(b1)  # N: Revealed type is "str"
+        reveal_type(a1)  # N: Revealed type is "builtins.int"
+        reveal_type(b1)  # N: Revealed type is "builtins.str"
 
 m2: tuple[int, str] | tuple[float, str]
 match m2:
     case (a2, b2):
-        reveal_type(a2)  # N: Revealed type is "Union[int, float]"
-        reveal_type(b2)  # N: Revealed type is "str"
+        reveal_type(a2)  # N: Revealed type is "Union[builtins.int, builtins.float]"
+        reveal_type(b2)  # N: Revealed type is "builtins.str"
 
 m3: tuple[int] | tuple[float, str]
 match m3:
     case (a3, b3):
-        reveal_type(a3)  # N: Revealed type is "float"
-        reveal_type(b3)  # N: Revealed type is "str"
+        reveal_type(a3)  # N: Revealed type is "builtins.float"
+        reveal_type(b3)  # N: Revealed type is "builtins.str"
 
 m4: tuple[int] | list[str]
 match m4:
     case (a4, b4):
-        reveal_type(a4)  # N: Revealed type is "float"
-        reveal_type(b4)  # N: Revealed type is "str"
+        reveal_type(a4)  # N: Revealed type is "builtins.str"
+        reveal_type(b4)  # N: Revealed type is "builtins.str"
+
+# properly handles unpack when all other patterns are not sequences
+m5: tuple[int, Unpack[tuple[float, ...]]] | None
+match m5:
+    case (a5, b5):
+        reveal_type(a5)  # N: Revealed type is "builtins.int"
+        reveal_type(b5)  # N: Revealed type is "builtins.float"
+
+# currently can't handle combing unpacking with other sequence patterns, if this happens revert to worst case
+# of combing all types
+m6: tuple[int, Unpack[tuple[float, ...]]] | list[str]
+match m6:
+    case (a6, b6):
+        reveal_type(a6)  # N: Revealed type is "Union[builtins.int, builtins.float, builtins.str]"
+        reveal_type(b6)  # N: Revealed type is "Union[builtins.int, builtins.float, builtins.str]"
+
+# but do still seperate types from non unpacked types
+m7: tuple[int, Unpack[tuple[float, ...]]] | tuple[str, bool]
+match m7:
+    case (a7, b7, *rest7):
+        reveal_type(a7)  # N: Revealed type is "Union[builtins.int, builtins.float, builtins.str]"
+        reveal_type(b7)  # N: Revealed type is "Union[builtins.int, builtins.float, builtins.bool]"
+        reveal_type(rest7)  # N: Revealed type is "builtins.list[Union[builtins.int, builtins.float]]"
+
+# verify that if we are unpacking, it will get the type of the sequence if the tuple is too short
+m8: tuple[int, str] | list[float]
+match m8:
+    case (a8, b8, *rest8):
+        reveal_type(a8)  # N: Revealed type is "Union[builtins.int, builtins.float]"
+        reveal_type(b8)  # N: Revealed type is "Union[builtins.str, builtins.float]"
+        reveal_type(rest8)  # N: Revealed type is "builtins.list[builtins.float]"
 
 [builtins fixtures/tuple.pyi]
 

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1559,12 +1559,30 @@ match m6:
 
 [builtins fixtures/tuple.pyi]
 
-[case testMatchTupleFields]
-x: tuple[int, str] | None
-match x:
-    case (a, b):
-        reveal_type(a)  # N: Revealed type is "int"
-        reveal_type(b)  # N: Revealed type is "str"
+[case testMatchTupleUnions]
+m1: tuple[int, str] | None
+match m1:
+    case (a1, b1):
+        reveal_type(a1)  # N: Revealed type is "int"
+        reveal_type(b1)  # N: Revealed type is "str"
+
+m2: tuple[int, str] | tuple[float, str]
+match m2:
+    case (a2, b2):
+        reveal_type(a2)  # N: Revealed type is "Union[int, float]"
+        reveal_type(b2)  # N: Revealed type is "str"
+
+m3: tuple[int] | tuple[float, str]
+match m3:
+    case (a3, b3):
+        reveal_type(a3)  # N: Revealed type is "float"
+        reveal_type(b3)  # N: Revealed type is "str"
+
+m4: tuple[int] | list[str]
+match m4:
+    case (a4, b4):
+        reveal_type(a4)  # N: Revealed type is "float"
+        reveal_type(b4)  # N: Revealed type is "str"
 
 [builtins fixtures/tuple.pyi]
 


### PR DESCRIPTION
This pull request fixes handling of union types containing tuples in match statements. Previously, when a tuple was part of a union, all its items would be unioned together and treated as a homogeneous tuple of that union type, which was incorrect.

It still fallbacks on this behavior if we there are multiple tuples in the union with Unpack in them, but otherwise now it should be handled correctly.

I attempted to keep as much of the existing semantics the same besides for this change. I also tried to keep the performance roughly similar, not unioning types more than needed.

Closes https://github.com/python/mypy/issues/19599